### PR TITLE
Update usage of k8s client to get daemonset

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,9 +2,9 @@ package client
 
 import (
 	"k8s.io/client-go/kubernetes"
+	v1app "k8s.io/client-go/kubernetes/typed/apps/v1"
 	v1batch "k8s.io/client-go/kubernetes/typed/batch/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	v1beta1extensions "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 )
 
@@ -12,7 +12,7 @@ type ClientInterface interface {
 	Pods(string) v1core.PodInterface
 	Jobs(string) v1batch.JobInterface
 	Endpoints(string) v1core.EndpointsInterface
-	DaemonSets(string) v1beta1extensions.DaemonSetInterface
+	DaemonSets(string) v1app.DaemonSetInterface
 	Services(string) v1core.ServiceInterface
 }
 type Client struct {
@@ -30,8 +30,8 @@ func (c Client) Jobs(namespace string) v1batch.JobInterface {
 func (c Client) Endpoints(namespace string) v1core.EndpointsInterface {
 	return c.Clientset.Core().Endpoints(namespace)
 }
-func (c Client) DaemonSets(namespace string) v1beta1extensions.DaemonSetInterface {
-	return c.Clientset.Extensions().DaemonSets(namespace)
+func (c Client) DaemonSets(namespace string) v1app.DaemonSetInterface {
+	return c.Clientset.AppsV1().DaemonSets(namespace)
 }
 
 func (c Client) Services(namespace string) v1core.ServiceInterface {


### PR DESCRIPTION
apiversion chagned after k8s upgradation, fix bug that
how to get daemonset objects

ref: https://github.com/stackanetes/stackanetes/issues/158